### PR TITLE
Properly initialize fugitive in existing buffers

### DIFF
--- a/config/plugins.yaml
+++ b/config/plugins.yaml
@@ -136,6 +136,7 @@
 
 - repo: tpope/vim-fugitive
   on_cmd: [ Git, Gcommit, Gblame, Gstatus, Gitdiff, Gbrowse ]
+  hook_post_source: bufdo call fugitive#detect(expand('%:p'))
 
 - repo: gregsexton/gitv
   depends: vim-fugitive


### PR DESCRIPTION
Fugitive installs buffer-local commands (Gstatus, Gblame, etc.)
when it has detected that a buffer is in a git repository.  The problem
with lazy-initialization is that if you open two buffers (both in git
repositories), call :Gstatus in one, and then try to run :Gstatus in
the other you'll simply get an error about "Not an editor command"

This adds a hook_post_source to call the fugitive git detection
in all existing buffers after loading fugitive.