### PR TITLE
fix neosnippet#snippets_directory settings

### DIFF
--- a/config/plugins.yaml
+++ b/config/plugins.yaml
@@ -295,7 +295,7 @@
   if: empty($VIM_MINIMAL)
   on_event: InsertCharPre
   on_ft: snippet
-  hook_add: let g:neosnippet#data_directory = $VARPATH.'/snippets'
+  hook_add: let g:neosnippet#snippets_directory = $VARPATH.'/snippets'
   hook_source: |
     let g:neosnippet#enable_snipmate_compatibility = 1
     let g:neosnippet#enable_completed_snippet = 1


### PR DESCRIPTION
from https://github.com/Shougo/neosnippet.vim

it should be
```
" Tell Neosnippet about the other snippets
let g:neosnippet#snippets_directory='~/.vim/bundle/vim-snippets/snippets'
```