### PR TITLE
Use persistent NerdTree across tabs plugin

### DIFF
--- a/config/plugins.yaml
+++ b/config/plugins.yaml
@@ -131,6 +131,7 @@
   on_map: { n: <Plug> }
   hook_post_source: source $VIMPATH/config/plugins/nerdtree.vim
 
+- { repo: jistr/vim-nerdtree-tabs, on_source: nerdtree }
 - { repo: Xuyuanp/nerdtree-git-plugin, on_source: nerdtree }
 - { repo: tpope/vim-commentary, on_map: <Plug>Commentary }
 - { repo: t9md/vim-choosewin, on_map: { n: <Plug> }}

--- a/config/plugins/all.vim
+++ b/config/plugins/all.vim
@@ -70,7 +70,7 @@ if dein#tap('nerdtree')
 	let g:NERDTreeMapToggleHidden = '.'
 
 	nnoremap <silent> <LocalLeader>e :<C-u>NERDTreeToggle<CR>
-	nnoremap <silent> <LocalLeader>a :<C-u>NERDTreeFind<CR>
+	nnoremap <silent> <LocalLeader>a :<C-u>NERDTreeTabsToggle<CR>
 endif
 
 if dein#tap('neosnippet.vim')


### PR DESCRIPTION
Adding this in case you're interested. Plugin persists your NerdTree toggle across all tabs. I also "let g:NERDTreeQuitOnOpen = 0" with this config for better control of when the NerdTree bar is displayed or not. 

https://github.com/jistr/vim-nerdtree-tabs