### PR TITLE
allowing vim session to be saved and restored using dir

### DIFF
--- a/config/mappings.vim
+++ b/config/mappings.vim
@@ -257,8 +257,9 @@ noremap  mk :m-2<CR>
 noremap  mj :m+<CR>
 
 " Last session management shortcuts
-nmap <Leader>se :<C-u>SessionSave last<CR>
-nmap <Leader>os :<C-u>execute 'source '.g:session_directory.'/last.vim'<CR>
+" nmap <Leader>se :<C-u>SessionSave last<CR>
+nmap <silent> <Leader>se :<C-u>execute 'SessionSave' fnamemodify(resolve(getcwd()), ':p:gs?/?_?')<CR>
+nmap <silent> <Leader>os :<C-u>execute 'source '.g:session_directory.'/'.fnamemodify(resolve(getcwd()), ':p:gs?/?_?').'.vim'<CR>
 
 if has('mac')
 	" Open the macOS dictionary on current word


### PR DESCRIPTION
The current working vim session can be saved using it's directory as the session name.

Workflow:
- Have all working window open
- `<Leader>se` will save the current session.
- `:qa` will close all the windows (this is mapped to `<A-q>` in my custom mapping)
- reopen vim, and do `<Leader>os` to restore session