### PR TITLE
PyYAML 5.1 safe_load

### DIFF
--- a/config/vimrc
+++ b/config/vimrc
@@ -76,7 +76,7 @@ function! s:dein_load_yaml(filename) abort
 	python3 << endpython
 import vim, yaml
 with open(vim.eval('a:filename'), 'r') as f:
-	vim.vars['denite_plugins'] = yaml.load(f.read())
+	vim.vars['denite_plugins'] = yaml.safe_load(f.read())
 endpython
 	endif
 


### PR DESCRIPTION
Issue if the version of PyYAML is 5.1 or upper
https://github.com/yaml/pyyaml/wiki/PyYAML-yaml.load(input)-Deprecation

Used the SafeLoader to avoid the warning ( -> the warning crash the plugin updates ). 

``yaml.warnings({'YAMLLoadWarning': False})`` should work also, to be compatible with older version of PyYAML