### PR TITLE
Remove airline config from neomake

### DIFF
--- a/config/plugins/neomake.vim
+++ b/config/plugins/neomake.vim
@@ -3,7 +3,6 @@
 " ---------
 let g:neomake_open_list = 0
 let g:neomake_verbose = 1
-let g:airline#extensions#neomake#enabled = 0
 
 if ! empty(g:python3_host_prog)
 	let g:neomake_python_python_exe = g:python3_host_prog


### PR DESCRIPTION
Your vim config doesn't actually install airline, so it shouldn't have configuration for it either. Then it can be done in local.plugins.yaml instead.