### PR TITLE
Fix ripgrep grepformat for quickfix window.

### DIFF
--- a/config/general.vim
+++ b/config/general.vim
@@ -173,7 +173,7 @@ if exists('+inccommand')
 endif
 
 if executable('rg')
-	set grepformat=%f:%l:%m
+	set grepformat=%f:%l:%c:%m
 	let &grepprg = 'rg --vimgrep' . (&smartcase ? ' --smart-case' : '')
 elseif executable('ag')
 	set grepformat=%f:%l:%m


### PR DESCRIPTION
Fixes problem where the quickfix window will not parse the returned "col" number from ripgrep.