### PR TITLE
Fix setlocal shada error when not using neovim

### DIFF
--- a/config/general.vim
+++ b/config/general.vim
@@ -123,13 +123,20 @@ if exists('&backupskip')
 	set backupskip+=.vault.vim
 endif
 
-" Disable swap/undo/viminfo/shada files in temp directories or shm
+" Disable swap/undo/viminfo files in temp directories or shm
 augroup user_secure
 	autocmd!
 	silent! autocmd BufNewFile,BufReadPre
 		\ /tmp/*,$TMPDIR/*,$TMP/*,$TEMP/*,*/shm/*,/private/var/*,.vault.vim
-		\ setlocal noswapfile noundofile nobackup nowritebackup viminfo= shada=
+		\ setlocal noswapfile noundofile nobackup nowritebackup viminfo=
 augroup END
+" Disable shada files in temp directories or shm
+if has('nvim')
+	augroup user_secure
+		silent! autocmd BufNewFile,BufReadPre
+			\ setlocal shada=
+	augroup END
+endif
 
 " }}}
 " Tabs and Indents {{{

--- a/config/general.vim
+++ b/config/general.vim
@@ -134,6 +134,7 @@ augroup END
 if has('nvim')
 	augroup user_secure
 		silent! autocmd BufNewFile,BufReadPre
+			\ /tmp/*,$TMPDIR/*,$TMP/*,$TEMP/*,*/shm/*,/private/var/*,.vault.vim
 			\ setlocal shada=
 	augroup END
 endif


### PR DESCRIPTION
When using vim and opening a file in the temp directory, the vim config will
attempt to set the shada setting, resulting in an error:

```
E518: Unknown option: shada=
```

This also seemed to throw errors when opening certain editor panes, such as
git blame. This PR fixes that error by only running that setlocal when running
in Neovim.