### PR TITLE
Replace deprecated `persisted` callbacks with user events

### DIFF
--- a/lua/plugins/persisted.lua
+++ b/lua/plugins/persisted.lua
@@ -42,6 +42,6 @@ vim.api.nvim_create_autocmd({ "User" }, {
   group = group,
   callback = function(session)
 		persisted.start()
-		print('Started session ' .. session.name)
+		print('Started session ' .. session.data.name)
   end,
 })

--- a/lua/plugins/persisted.lua
+++ b/lua/plugins/persisted.lua
@@ -16,19 +16,32 @@ persisted.setup({
 	follow_cwd = false,
 	use_git_branch = false,
 	ignored_dirs = { '/tmp', '~/.cache' },
+})
 
-	before_save = function()
+local group = vim.api.nvim_create_augroup("PersistedHooks", {})
+
+vim.api.nvim_create_autocmd({ "User" }, {
+  pattern = "PersistedSavePre",
+  group = group,
+  callback = function()
 		require('interface').win.close_plugin_owned()
-	end,
+  end,
+})
 
-	telescope = {
-		before_source = function()
-	 		persisted.save()
-			persisted.stop()
-		end,
-		after_source = function(session)
-			persisted.start()
-			print('Started session ' .. session.name)
-		end
-	}
+vim.api.nvim_create_autocmd({ "User" }, {
+  pattern = "PersistedTelescopeLoadPre",
+  group = group,
+  callback = function()
+		persisted.save()
+		persisted.stop()
+  end,
+})
+
+vim.api.nvim_create_autocmd({ "User" }, {
+  pattern = "PersistedTelescopeLoadPre",
+  group = group,
+  callback = function(session)
+		persisted.start()
+		print('Started session ' .. session.name)
+  end,
 })


### PR DESCRIPTION
I ran a `make update` today and noticed this warning every time I opened vim

```
Please replace with the PersistedSavePre user event. This will be removed from the plugin on 2023-03-05
----------
The use of the telescope.before_source callback.
Please replace with the PersistedTelescopeLoadPre user event. This will be removed from the plugin on 2023-03-05
----------
The use of the telescope.after_source callback.
Please replace with the PersistedTelescopeLoadPost user event. This will be removed from the plugin on 2023-03-05
----------
See https://github.com/olimorris/persisted.nvim/issues/51 for more information.
```
https://github.com/olimorris/persisted.nvim/issues/51 <-- link the issue from the error

Following the instructions from the issue above I was able to fix this by removing the callbacks. I did some simple testing and it seemed to work. 

This is my first time contributing to anything in lua or vim config related so if there is a better way to fix this please let me know or feel free to close this PR and fix it the better way if there is one.