### PR TITLE
fix(autocmds): fix lastloc

### DIFF
--- a/lua/rafi/config/autocmds.lua
+++ b/lua/rafi/config/autocmds.lua
@@ -26,7 +26,7 @@ vim.api.nvim_create_autocmd('BufReadPost', {
 		local mark = vim.api.nvim_buf_get_mark(buf, '"')
 		local lcount = vim.api.nvim_buf_line_count(buf)
 		if mark[1] > 0 and mark[1] <= lcount then
-			pcall(vim.api.nvim_win_set_cursor, buf, mark)
+			pcall(vim.api.nvim_win_set_cursor, 0, mark)
 		end
 	end,
 })


### PR DESCRIPTION
nvim_win_set_cursor takes a window as its first argument, not a buf, which breaks this autocmd. changing the argument to 0 correctly uses the current window.

While I'm here: *thank you* for maintaining your nvim config the way you do. I've been basing my own on it for years now, and it's always been exactly the right amount of completeness vs hackability for me. The update to lazy.nvim in particular was really great :+1: 