### PR TITLE
fix: Lightbulb setup error

### DIFF
--- a/lua/rafi/plugins/extras/lsp/lightbulb.lua
+++ b/lua/rafi/plugins/extras/lsp/lightbulb.lua
@@ -3,7 +3,9 @@ return {
 		'kosayoda/nvim-lightbulb',
 		event = { 'BufReadPre', 'BufNewFile' },
 		opts = {
-			ignore = { 'null-ls' },
+			ignore = {
+				clients = { 'null-ls' },
+			},
 		},
 		config = function(_, opts)
 			require('nvim-lightbulb').setup(opts)


### PR DESCRIPTION
This should fix:
```
   Error  08:55:20 notify.error lazy.nvim Failed to run `config` for nvim-lightbulb

...e/nvim/lazy/nvim-lightbulb/lua/nvim-lightbulb/config.lua:176: ignore.ft: expected table, got nil

# stacktrace:
  - vim/shared.lua:0 _in_ **validate**
  - lua/rafi/plugins/extras/lsp/lightbulb.lua:9 _in_ **config**
  - vim/_editor.lua:0
  - /persisted.nvim/lua/persisted/utils.lua:69 _in_ **load_session**
  - /persisted.nvim/lua/persisted/init.lua:101 _in_ **load**
  - /persisted.nvim/lua/persisted/init.lua:118
```