### PR TITLE
Chore: Updated Indent-Blankline

### DIFF
--- a/lua/rafi/plugins/ui.lua
+++ b/lua/rafi/plugins/ui.lua
@@ -221,6 +221,7 @@ return {
 		keys = {
 			{ '<Leader>ue', '<cmd>IndentBlanklineToggle<CR>' },
 		},
+		main = "ibl",
 		opts = {
 			show_trailing_blankline_indent = false,
 			disable_with_nolist = true,


### PR DESCRIPTION
Indent Blankline has breaking changes in its major version update. This Change was following the Wiki: https://github.com/lukas-reineke/indent-blankline.nvim/wiki/Migrate-to-version-3

Otherwise you'll receive:

```
You are trying to call the setup function of indent-blankline version 2, but you have version 3 installed.
Take a look at the GitHub wiki for instructions on how to migrate, or revert back to version 2.
```